### PR TITLE
feat: Prometheus middleware to support paths to exclude

### DIFF
--- a/aiohttp_prometheus_exporter/middleware.py
+++ b/aiohttp_prometheus_exporter/middleware.py
@@ -58,9 +58,7 @@ def prometheus_middleware_factory(
     )
 
     @middleware
-    async def prometheus_middleware(
-        request: Request, handler: Callable[[Request], Awaitable[Response]]
-    ):
+    async def prometheus_middleware(request: Request, handler: Callable[[Request], Awaitable[Response]]):
         loop = get_loop()
 
         try:

--- a/aiohttp_prometheus_exporter/middleware.py
+++ b/aiohttp_prometheus_exporter/middleware.py
@@ -58,7 +58,9 @@ def prometheus_middleware_factory(
     )
 
     @middleware
-    async def prometheus_middleware(request: Request, handler: Callable[[Request], Awaitable[Response]]):
+    async def prometheus_middleware(
+        request: Request, handler: Callable[[Request], Awaitable[Response]]
+    ):
         loop = get_loop()
 
         try:

--- a/aiohttp_prometheus_exporter/trace.py
+++ b/aiohttp_prometheus_exporter/trace.py
@@ -20,7 +20,9 @@ class MetricsStore:
 
         self.requests_in_progress_metrics = prometheus_client.Gauge(
             name=f"aiohttp_client_requests_in_progress",
-            documentation="Gauge of client requests by client name, method, scheme and remote currently being processed.",
+            documentation=(
+                "Gauge of client requests by client name, method, scheme and remote currently being processed."
+            ),
             labelnames=["client_name", "method", "scheme", "remote"],
             namespace=namespace,
             registry=registry,
@@ -28,7 +30,10 @@ class MetricsStore:
 
         self.requests_processing_time_metrics = prometheus_client.Histogram(
             name=f"aiohttp_client_request_duration",
-            documentation="Histogram of requests processing time by client name, method, scheme, remote and status code (in seconds).",
+            documentation=(
+                "Histogram of requests processing time by client name, method, scheme, remote and status "
+                "code (in seconds)."
+            ),
             labelnames=["client_name", "method", "scheme", "remote", "status_code"],
             unit="seconds",
             namespace=namespace,
@@ -191,9 +196,7 @@ class PrometheusTraceConfig(aiohttp.TraceConfig):
         loop = get_loop()
         request_end_time = loop.time()
 
-        request_start_time = getattr(
-            trace_config_ctx, "_request_start_time", request_end_time
-        )
+        request_start_time = getattr(trace_config_ctx, "_request_start_time", request_end_time)
 
         self.metrics.requests_in_progress_metrics.labels(
             client_name=self.client_name,
@@ -224,9 +227,7 @@ class PrometheusTraceConfig(aiohttp.TraceConfig):
         trace_config_ctx: SimpleNamespace,
         params: aiohttp.TraceRequestChunkSentParams,
     ) -> None:
-        self.metrics.requests_chunks_sent_metrics.labels(
-            client_name=self.client_name
-        ).inc(len(params.chunk))
+        self.metrics.requests_chunks_sent_metrics.labels(client_name=self.client_name).inc(len(params.chunk))
 
     async def __on_response_chunk_received(
         self,
@@ -234,9 +235,7 @@ class PrometheusTraceConfig(aiohttp.TraceConfig):
         trace_config_ctx: SimpleNamespace,
         params: aiohttp.TraceResponseChunkReceivedParams,
     ) -> None:
-        self.metrics.requests_chunks_received_metrics.labels(
-            client_name=self.client_name
-        ).inc(len(params.chunk))
+        self.metrics.requests_chunks_received_metrics.labels(client_name=self.client_name).inc(len(params.chunk))
 
     async def __on_request_exception(
         self,
@@ -313,9 +312,9 @@ class PrometheusTraceConfig(aiohttp.TraceConfig):
             "_connection_queued_start_time",
             connection_queued_end_time,
         )
-        self.metrics.connection_queued_time_metrics.labels(
-            client_name=self.client_name
-        ).observe(connection_queued_end_time - connection_queued_start_time)
+        self.metrics.connection_queued_time_metrics.labels(client_name=self.client_name).observe(
+            connection_queued_end_time - connection_queued_start_time
+        )
 
     @staticmethod
     async def __on_connection_create_start(
@@ -339,9 +338,9 @@ class PrometheusTraceConfig(aiohttp.TraceConfig):
             "_connection_create_start_time",
             connection_create_end_time,
         )
-        self.metrics.connection_create_time_metrics.labels(
-            client_name=self.client_name
-        ).observe(connection_create_end_time - connection_create_start_time)
+        self.metrics.connection_create_time_metrics.labels(client_name=self.client_name).observe(
+            connection_create_end_time - connection_create_start_time
+        )
 
     async def __on_connection_reuseconn(
         self,
@@ -349,9 +348,7 @@ class PrometheusTraceConfig(aiohttp.TraceConfig):
         trace_config_ctx: SimpleNamespace,
         params: aiohttp.TraceConnectionReuseconnParams,
     ) -> None:
-        self.metrics.connection_reuseconn_metrics.labels(
-            client_name=self.client_name
-        ).inc()
+        self.metrics.connection_reuseconn_metrics.labels(client_name=self.client_name).inc()
 
     @staticmethod
     async def __on_dns_resolvehost_start(
@@ -370,12 +367,10 @@ class PrometheusTraceConfig(aiohttp.TraceConfig):
     ) -> None:
         loop = get_loop()
         dns_resolvehost_end_time = loop.time()
-        dns_resolvehost_start_time = getattr(
-            trace_config_ctx, "_dns_resolvehost_start_time", dns_resolvehost_end_time
+        dns_resolvehost_start_time = getattr(trace_config_ctx, "_dns_resolvehost_start_time", dns_resolvehost_end_time)
+        self.metrics.dns_resolvehost_metrics.labels(client_name=self.client_name, host=params.host).observe(
+            dns_resolvehost_end_time - dns_resolvehost_start_time
         )
-        self.metrics.dns_resolvehost_metrics.labels(
-            client_name=self.client_name, host=params.host
-        ).observe(dns_resolvehost_end_time - dns_resolvehost_start_time)
 
     async def __on_dns_cache_hit(
         self,
@@ -383,9 +378,7 @@ class PrometheusTraceConfig(aiohttp.TraceConfig):
         trace_config_ctx: SimpleNamespace,
         params: aiohttp.TraceDnsCacheHitParams,
     ) -> None:
-        self.metrics.dns_cache_hit_metrics.labels(
-            client_name=self.client_name, host=params.host
-        ).inc()
+        self.metrics.dns_cache_hit_metrics.labels(client_name=self.client_name, host=params.host).inc()
 
     async def __on_dns_cache_miss(
         self,
@@ -393,6 +386,4 @@ class PrometheusTraceConfig(aiohttp.TraceConfig):
         trace_config_ctx: SimpleNamespace,
         params: aiohttp.TraceDnsCacheMissParams,
     ) -> None:
-        self.metrics.dns_cache_miss_metrics.labels(
-            client_name=self.client_name, host=params.host
-        ).inc()
+        self.metrics.dns_cache_miss_metrics.labels(client_name=self.client_name, host=params.host).inc()

--- a/aiohttp_prometheus_exporter/trace.py
+++ b/aiohttp_prometheus_exporter/trace.py
@@ -196,7 +196,9 @@ class PrometheusTraceConfig(aiohttp.TraceConfig):
         loop = get_loop()
         request_end_time = loop.time()
 
-        request_start_time = getattr(trace_config_ctx, "_request_start_time", request_end_time)
+        request_start_time = getattr(
+            trace_config_ctx, "_request_start_time", request_end_time
+        )
 
         self.metrics.requests_in_progress_metrics.labels(
             client_name=self.client_name,
@@ -227,7 +229,9 @@ class PrometheusTraceConfig(aiohttp.TraceConfig):
         trace_config_ctx: SimpleNamespace,
         params: aiohttp.TraceRequestChunkSentParams,
     ) -> None:
-        self.metrics.requests_chunks_sent_metrics.labels(client_name=self.client_name).inc(len(params.chunk))
+        self.metrics.requests_chunks_sent_metrics.labels(
+            client_name=self.client_name
+        ).inc(len(params.chunk))
 
     async def __on_response_chunk_received(
         self,
@@ -235,7 +239,9 @@ class PrometheusTraceConfig(aiohttp.TraceConfig):
         trace_config_ctx: SimpleNamespace,
         params: aiohttp.TraceResponseChunkReceivedParams,
     ) -> None:
-        self.metrics.requests_chunks_received_metrics.labels(client_name=self.client_name).inc(len(params.chunk))
+        self.metrics.requests_chunks_received_metrics.labels(
+            client_name=self.client_name
+        ).inc(len(params.chunk))
 
     async def __on_request_exception(
         self,
@@ -312,9 +318,9 @@ class PrometheusTraceConfig(aiohttp.TraceConfig):
             "_connection_queued_start_time",
             connection_queued_end_time,
         )
-        self.metrics.connection_queued_time_metrics.labels(client_name=self.client_name).observe(
-            connection_queued_end_time - connection_queued_start_time
-        )
+        self.metrics.connection_queued_time_metrics.labels(
+            client_name=self.client_name
+        ).observe(connection_queued_end_time - connection_queued_start_time)
 
     @staticmethod
     async def __on_connection_create_start(
@@ -338,9 +344,9 @@ class PrometheusTraceConfig(aiohttp.TraceConfig):
             "_connection_create_start_time",
             connection_create_end_time,
         )
-        self.metrics.connection_create_time_metrics.labels(client_name=self.client_name).observe(
-            connection_create_end_time - connection_create_start_time
-        )
+        self.metrics.connection_create_time_metrics.labels(
+            client_name=self.client_name
+        ).observe(connection_create_end_time - connection_create_start_time)
 
     async def __on_connection_reuseconn(
         self,
@@ -348,7 +354,9 @@ class PrometheusTraceConfig(aiohttp.TraceConfig):
         trace_config_ctx: SimpleNamespace,
         params: aiohttp.TraceConnectionReuseconnParams,
     ) -> None:
-        self.metrics.connection_reuseconn_metrics.labels(client_name=self.client_name).inc()
+        self.metrics.connection_reuseconn_metrics.labels(
+            client_name=self.client_name
+        ).inc()
 
     @staticmethod
     async def __on_dns_resolvehost_start(
@@ -367,10 +375,12 @@ class PrometheusTraceConfig(aiohttp.TraceConfig):
     ) -> None:
         loop = get_loop()
         dns_resolvehost_end_time = loop.time()
-        dns_resolvehost_start_time = getattr(trace_config_ctx, "_dns_resolvehost_start_time", dns_resolvehost_end_time)
-        self.metrics.dns_resolvehost_metrics.labels(client_name=self.client_name, host=params.host).observe(
-            dns_resolvehost_end_time - dns_resolvehost_start_time
+        dns_resolvehost_start_time = getattr(
+            trace_config_ctx, "_dns_resolvehost_start_time", dns_resolvehost_end_time
         )
+        self.metrics.dns_resolvehost_metrics.labels(
+            client_name=self.client_name, host=params.host
+        ).observe(dns_resolvehost_end_time - dns_resolvehost_start_time)
 
     async def __on_dns_cache_hit(
         self,
@@ -378,7 +388,9 @@ class PrometheusTraceConfig(aiohttp.TraceConfig):
         trace_config_ctx: SimpleNamespace,
         params: aiohttp.TraceDnsCacheHitParams,
     ) -> None:
-        self.metrics.dns_cache_hit_metrics.labels(client_name=self.client_name, host=params.host).inc()
+        self.metrics.dns_cache_hit_metrics.labels(
+            client_name=self.client_name, host=params.host
+        ).inc()
 
     async def __on_dns_cache_miss(
         self,
@@ -386,4 +398,6 @@ class PrometheusTraceConfig(aiohttp.TraceConfig):
         trace_config_ctx: SimpleNamespace,
         params: aiohttp.TraceDnsCacheMissParams,
     ) -> None:
-        self.metrics.dns_cache_miss_metrics.labels(client_name=self.client_name, host=params.host).inc()
+        self.metrics.dns_cache_miss_metrics.labels(
+            client_name=self.client_name, host=params.host
+        ).inc()

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = ['aiohttp>=3', 'prometheus_client>=0.6', ]
 
 setup_requirements = ['pytest-runner', ]
 
-test_requirements = ['pytest>=3', ]
+test_requirements = ['pytest>=3', 'pytest-aiohttp>=0.3.0']
 
 setup(
     author="Adrian Krupa",

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -20,7 +20,9 @@ def app(request):
     registry = prometheus_client.CollectorRegistry()
     excluded_paths = request.param if hasattr(request, "param") else ()
 
-    app.middlewares.append(prometheus_middleware_factory(registry=registry, excluded_paths=excluded_paths))
+    app.middlewares.append(
+        prometheus_middleware_factory(registry=registry, excluded_paths=excluded_paths)
+    )
     app.router.add_get("/metrics", metrics(registry=registry))
 
     @routes.get("/200")
@@ -193,7 +195,9 @@ class TestMiddleware:
             1.0,
         )
 
-    @pytest.mark.parametrize("app", (["metrics", "something-to-exclude"],), indirect=True)
+    @pytest.mark.parametrize(
+        "app", (["metrics", "something-to-exclude"],), indirect=True
+    )
     async def test_ensure_excluded_paths_are_not_present(self, client: TestClient, app):
         await client.get("/200")
         await client.get("/something-to-exclude")

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -162,7 +162,9 @@ class TestTrace:
             f"{namespace_prefix}aiohttp_client_chunks_sent_bytes",
             f"{namespace_prefix}aiohttp_client_chunks_sent_bytes_total",
             0.0,
-            labels={"client_name": client_name,},
+            labels={
+                "client_name": client_name,
+            },
         )
 
         assert_metric_value(
@@ -170,14 +172,18 @@ class TestTrace:
             f"{namespace_prefix}aiohttp_client_chunks_received_bytes",
             f"{namespace_prefix}aiohttp_client_chunks_received_bytes_total",
             26.0,
-            labels={"client_name": client_name,},
+            labels={
+                "client_name": client_name,
+            },
         )
 
         assert_metric_exists(
             current_frozen_registry,
             f"{namespace_prefix}aiohttp_client_connection_create_seconds",
             f"{namespace_prefix}aiohttp_client_connection_create_seconds_bucket",
-            labels={"client_name": client_name,},
+            labels={
+                "client_name": client_name,
+            },
         )
 
     async def test_parallel_connection(
@@ -198,7 +204,9 @@ class TestTrace:
             current_frozen_registry,
             f"{namespace_prefix}aiohttp_client_connection_create_seconds",
             f"{namespace_prefix}aiohttp_client_connection_create_seconds_bucket",
-            labels={"client_name": client_name,},
+            labels={
+                "client_name": client_name,
+            },
         )
 
         assert_metric_value(
@@ -206,7 +214,9 @@ class TestTrace:
             f"{namespace_prefix}aiohttp_client_connection_reuseconn",
             f"{namespace_prefix}aiohttp_client_connection_reuseconn_total",
             1.0,
-            labels={"client_name": client_name,},
+            labels={
+                "client_name": client_name,
+            },
         )
 
     async def test_redirect(
@@ -333,21 +343,30 @@ class TestTrace:
             current_frozen_registry,
             f"{namespace_prefix}aiohttp_client_dns_resolvehost_seconds",
             f"{namespace_prefix}aiohttp_client_dns_resolvehost_seconds_bucket",
-            labels={"client_name": client_name, "host": "www.google.com",},
+            labels={
+                "client_name": client_name,
+                "host": "www.google.com",
+            },
         )
 
         assert_metric_exists(
             current_frozen_registry,
             f"{namespace_prefix}aiohttp_client_dns_cache_miss",
             f"{namespace_prefix}aiohttp_client_dns_cache_miss_total",
-            labels={"client_name": client_name, "host": "www.google.com",},
+            labels={
+                "client_name": client_name,
+                "host": "www.google.com",
+            },
         )
 
         assert_metric_exists(
             current_frozen_registry,
             f"{namespace_prefix}aiohttp_client_dns_cache_hit",
             f"{namespace_prefix}aiohttp_client_dns_cache_hit_total",
-            labels={"client_name": client_name, "host": "www.google.com",},
+            labels={
+                "client_name": client_name,
+                "host": "www.google.com",
+            },
         )
 
 


### PR DESCRIPTION
Currently, there is no way to exclude some paths from the Prometheus registry. Sometimes this might be useful when we want to gather metrics only for resources that encapsulate some business-related logic.

The proposed changes are about to enable us with such a feature. So, in case you need to exclude some paths, just pass an argument `excluded_paths` with the list of paths and they will not be shown in the metrics report.

Example::
```
app.middlewares.append(
	prometheus_middleware_factory(
		registry=registry,
		excluded_paths=('/metrics', '/health', '/something-internal'))
	)
)
```